### PR TITLE
parse input from input field of profile page

### DIFF
--- a/src/config/account_config.js
+++ b/src/config/account_config.js
@@ -1,21 +1,30 @@
 import moment from 'moment'
+import {
+  formatDateInputFromPicker,
+  formatDatePickerFromInput,
+} from '@/utils/datetime.js'
 
 export default {
   persoonlijk: [
     { title: 'Voornaam', key: 'firstName' },
     { title: 'Achternaam', key: 'lastName' },
     {
-      title: 'Leeftijd',
+      title: 'Geboortedatum',
       key: 'dateOfBirth',
-      format: function(value) {
-        return moment().diff(value, 'years')
-      },
+      format: formatDateInputFromPicker,
+      parse: formatDatePickerFromInput,
     },
     {
       title: 'Interesses',
       key: 'interests',
       format: function(value) {
         return value.join(', ')
+      },
+      parse(value) {
+        return value
+          .split(',')
+          .map(s => s.trim())
+          .filter(s => s.length)
       },
     },
   ],

--- a/src/pages/profile/Account.vue
+++ b/src/pages/profile/Account.vue
@@ -120,14 +120,32 @@ export default {
   methods: {
     get: get,
     set: set,
+    findSelectedItem() {
+      // find item in account config whose key equals the selected property
+      for (const section in account_config) {
+        const item = account_config[section].find(
+          item => item.key === this.selectedProperty
+        )
+        if (item) {
+          return item
+        }
+      }
+      // should not happen (famous last words...)
+      return undefined
+    },
     onChangedInfoProperty(input) {
       // Fires when the user onfocusses the input
       //HACK: JSON parse/stringify to prevent "[vuex] do not mutate vuex store
       // state outside mutation handlers." error.
       let newProfile = JSON.parse(JSON.stringify(this.user))
+      // check for parse function in account config
+      const { parse } = this.findSelectedItem()
+      if (parse) {
+        // convert text input back to format that backend expects
+        input = parse(input)
+      }
       set(newProfile, this.selectedProperty, input)
       psStore.actions.updateProfile(newProfile)
-
       // Fetch geocode for address if different.
       if (!isEqual(this.user.address, newProfile.address)) {
         const query = this.addressQuery(newProfile.address)


### PR DESCRIPTION
er zat ook een bug bij het editen van de interesses. na een edit, werden alle interesses in 1 string gepropt.

de oplossing is nog niet ideaal.
- geen foutmeldingen bij foutieve input
- als gebruiker komma vergeet, worden interesses aan elkaar 'geplakt'

een generieke input component die met verschillende typen overweg kan (date, string array, boolean, etc.) zou beter zijn, maar is misschien een overkill. gebruikers zullen niet elke dag hun profiel gaan wijzigen...
