### PR TITLE
server response beter verwerken

### DIFF
--- a/src/store/itinerary-service/actions.ts
+++ b/src/store/itinerary-service/actions.ts
@@ -228,7 +228,7 @@ function fetchTrips(
       params: params,
     })
     .then(response => {
-      if (response.status === 200 && response.data.data.length > 0) {
+      if (response.status === 200) {
         if (offset === 0) {
           pastTrips
             ? mutations.setPastTrips(response.data.data)

--- a/src/store/itinerary-service/mutations.ts
+++ b/src/store/itinerary-service/mutations.ts
@@ -11,6 +11,11 @@ import {
   SearchCriteria,
 } from '@/store/itinerary-service/types'
 
+function safeConcatTrips(current: Trip[], additions: Trip[]) {
+  return current.concat(
+    additions.filter(trip => !current.some(existing => existing.id === trip.id))
+  )
+}
 function setSearchCriteria(state: ItineraryState, payload: SearchCriteria) {
   state.searchCriteria.from = payload.from
   state.searchCriteria.to = payload.to
@@ -79,7 +84,7 @@ function setPlannedTrips(state: ItineraryState, payload: Trip[]) {
 }
 
 function appendPlannedTrips(state: ItineraryState, payload: Trip[]) {
-  state.plannedTrips = state.plannedTrips.concat(payload)
+  state.plannedTrips = safeConcatTrips(state.plannedTrips, payload)
 }
 
 function setShoutOuts(state: ItineraryState, payload: ShoutOut[]) {
@@ -103,7 +108,7 @@ function setPastTrips(state: ItineraryState, payload: Trip[]) {
 }
 
 function appendPastTrips(state: ItineraryState, payload: Trip[]) {
-  state.pastTrips = state.pastTrips.concat(payload)
+  state.pastTrips = safeConcatTrips(state.pastTrips, payload)
 }
 
 function setPastTripsCount(state: ItineraryState, payload: number) {


### PR DESCRIPTION
ik heb zo veel mogelijk scenario's proberen te testen maar ik weet niet zeker of de simpele fix in de store alle mogelijke problemen oplost. het ingewikkelde is dat zowel de chauffeur als ook de passagier de reis kan annuleren. bijv: als de chauffeur annuleert, dan wordt de lijst van ritten voor de passagier niet 'automagisch' ververst. wat me ook opviel is dat de boeking wel verdwijnt als de passagier annuleert, maar de chauffeur kan nog steeds een bericht sturen naar de passagier (die niet meer meerijdt...)